### PR TITLE
Preserve legend selection state when changing series

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@ var data_feed_name = location.href.indexOf('feed=cds') < 0 ? 'csse' : 'cds';
 var csse = null,   // Cleaned data loaded from csse.
     chart = null,  // The main object, Chartist object.
     theapp = null; // Main application controller, Vue object.
+    legendStates = []; // Legend state is saved separately for each domain
 
 //////////////////////////////////////////////////////////////////////
 // By-day summarization.
@@ -545,7 +546,11 @@ function plot_series(extract, stat, scale, xaxis, yaxis) {
       }),
       // Must be last to not intefere with axis titles.
       Chartist.plugins.legend({
-        legendNames: extract.series.map(x => x[0])
+        legendNames: extract.series.map(x => x[0]),
+        legendState: legendStates[theapp.chosen_domain],
+        onClick: function(chart, e, legends) {
+          legendStates[theapp.chosen_domain] = legends;
+        }
       }),
       Chartist.plugins.ctPointLabels({
         textAnchor: 'middle'

--- a/index.html
+++ b/index.html
@@ -203,7 +203,6 @@ var data_feed_name = location.href.indexOf('feed=cds') < 0 ? 'csse' : 'cds';
 var csse = null,   // Cleaned data loaded from csse.
     chart = null,  // The main object, Chartist object.
     theapp = null; // Main application controller, Vue object.
-    legendStates = []; // Legend state is saved separately for each domain
 
 //////////////////////////////////////////////////////////////////////
 // By-day summarization.
@@ -547,9 +546,9 @@ function plot_series(extract, stat, scale, xaxis, yaxis) {
       // Must be last to not intefere with axis titles.
       Chartist.plugins.legend({
         legendNames: extract.series.map(x => x[0]),
-        legendState: legendStates[theapp.chosen_domain],
+        legendState: theapp.legendStates[theapp.chosen_domain],
         onClick: function(chart, e, legends) {
-          legendStates[theapp.chosen_domain] = legends;
+          theapp.legendStates[theapp.chosen_domain] = legends;
         }
       }),
       Chartist.plugins.ctPointLabels({
@@ -579,6 +578,7 @@ theapp = new Vue({
     stat_choices: ['totals', 'deltas'],
     scale_choices: ['linear', 'log10'],
     added_locality: null,
+    legendStates: []    // Legend state is saved separately for each domain
   },
   updated: function() {
     $('input').attr('autocomplete', 'none');

--- a/lib/chartist-plugin-legend.js
+++ b/lib/chartist-plugin-legend.js
@@ -24,6 +24,7 @@
         classNames: false,
         removeAll: false,
         legendNames: false,
+        legendState: false,
         clickable: true,
         onClick: null,
         position: 'top'
@@ -140,6 +141,25 @@
                 }
             }
 
+            function applyLegendStateToChart(legends, seriesMetadata, useLabels) {
+                var newSeries = [];
+                var newLabels = [];
+
+                for (var i = 0; i < seriesMetadata.length; i++) {
+                    if (seriesMetadata[i].legend != -1 && legends[seriesMetadata[i].legend].active) {
+                        newSeries.push(seriesMetadata[i].data);
+                        newLabels.push(seriesMetadata[i].label);
+                    }
+                }
+
+                chart.data.series = newSeries;
+                if (useLabels) {
+                    chart.data.labels = newLabels;
+                }
+
+                chart.update();
+            }
+
             function addClickHandler(legendElement, legends, seriesMetadata, useLabels) {
                 legendElement.addEventListener('click', function(e) {
                     var li = e.target;
@@ -176,25 +196,10 @@
                         }
                     }
 
-                    var newSeries = [];
-                    var newLabels = [];
-
-                    for (var i = 0; i < seriesMetadata.length; i++) {
-                        if (seriesMetadata[i].legend != -1 && legends[seriesMetadata[i].legend].active) {
-                            newSeries.push(seriesMetadata[i].data);
-                            newLabels.push(seriesMetadata[i].label);
-                        }
-                    }
-
-                    chart.data.series = newSeries;
-                    if (useLabels) {
-                        chart.data.labels = newLabels;
-                    }
-
-                    chart.update();
+                    applyLegendStateToChart(legends, seriesMetadata, useLabels);
 
                     if (options.onClick) {
-                        options.onClick(chart, e);
+                        options.onClick(chart, e, legends);
                     }
                 });
             }
@@ -221,12 +226,31 @@
                 legendSeries.forEach(function(seriesIndex) {
                     seriesMetadata[seriesIndex].legend = i;
                 });
+    
+                var active = true;
+                if (options.legendState) {
+                    var found = options.legendState.find(element => element.text == legendText);
+                    if (found) {
+                        active = found.active;
+                    }
+                    else {
+                        // If that location is not in the saved state, only make it
+                        // selected if everything that was saved is selected
+                        active = !options.legendState.find(element => !element.active);
+                    }
+                }
 
                 legends.push({
                     text: legendText,
                     series: legendSeries,
-                    active: true
+                    active: active
                 });
+
+                if (!active) {
+                    li.classList.add('inactive');
+                }
+
+                applyLegendStateToChart(legends, seriesMetadata, useLabels);
             });
 
             function createHandler(data) { 

--- a/lib/chartist-plugin-legend.js
+++ b/lib/chartist-plugin-legend.js
@@ -199,7 +199,7 @@
                     applyLegendStateToChart(legends, seriesMetadata, useLabels);
 
                     if (options.onClick) {
-                        options.onClick(chart, e, legends);
+                        options.onClick(chart, e, _.clone(legends));
                     }
                 });
             }


### PR DESCRIPTION
Here is my first crack at it.

Notes:

- I did not attempt to preserve the selected state on the URL
- It's preserving the state for each domain. So you can have a US selection, switch to Intl and make a different selection, then go back to US and still have your original selection
- There are some slightly odd cases due to the fact that switching from confirmed to death can change the list of locations. If you had only selected a location which then disappears, you end up with nothing. It could be argues it's by design when we preserve the selection.

Anyway, play with it and let me know what you think.