### PR TITLE
Persist the selected localities on the URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@ Customized charts are directly linkable by URL.  URL parameters can be edited di
 <tr><td>Start:</td><td><input v-model.lazy="chosen_start"> (>=num, or m/d/y)</td></tr>
 <tr><td>Top:</td><td><input v-model.lazy="chosen_top"> (integer)</td></tr>
 <tr><td>Include:</td><td><input v-model.lazy="chosen_include"> (';' between states)</td></tr>
+<tr><td>Select:</td><td><input v-model.lazy="chosen_select"> (';' between states)</td></tr>
 <tr><td>Theme:</td><td><input v-model.lazy="chosen_theme"> (white/dark/paper)</td></tr>
 <tr><td>Advanced:</td><td> <input v-model.lazy="chosen_advanced"> (1 or 0)</td></tr>
 <tr><td>Bare:</td><td> <input v-model.lazy="chosen_bare"> (1 or 0)</td></tr>
@@ -550,9 +551,11 @@ function plot_series(extract, stat, scale, xaxis, yaxis) {
       // Must be last to not intefere with axis titles.
       Chartist.plugins.legend({
         legendNames: extract.series.map(x => x[0]),
-        legendState: theapp.legendStates[theapp.chosen_domain],
+        legendState: getLegendState(),
         onClick: function(chart, e, legends) {
-          theapp.legendStates[theapp.chosen_domain] = legends;
+          // Persist the state, and remember what domain it's for
+          theapp.selectStateDomain = theapp.chosen_domain;
+          theapp.chosen_select = legends.length == 0 ? "" : legends.join(';');
         },
       }),
       Chartist.plugins.ctPointLabels({
@@ -562,6 +565,19 @@ function plot_series(extract, stat, scale, xaxis, yaxis) {
   });
   preparePrintChart(chart);
   return chart;
+}
+
+function getLegendState() {
+  if (theapp.selectStateDomain == null) {
+    // When the page is first loaded, this will be null
+    theapp.selectStateDomain = theapp.chosen_domain;
+  }
+  else if (theapp.selectStateDomain != theapp.chosen_domain) {
+    // If the saved state pertains to a different domain, ignore it
+    theapp.chosen_select = "";
+  }
+
+  return theapp.chosen_select == "" ? [] : theapp.chosen_select.split(';');
 }
 
 // Chartist has a fixed set of 26 classes it cycles through (e.g. ct-series-z)
@@ -616,7 +632,7 @@ theapp = new Vue({
     stat_choices: ['totals', 'deltas'],
     scale_choices: ['linear', 'log10'],
     added_locality: null,
-    legendStates: []    // Legend state is saved separately for each domain
+    selectStateDomain: null // The domain that the saved state is for
   },
   updated: function() {
     this.configure_suggest();
@@ -645,6 +661,7 @@ theapp = new Vue({
     chosen_start: url_property('start', '>=30'),
     chosen_top: url_property('top', '10'),
     chosen_include: url_property('include', ''),
+    chosen_select: url_property('select', ''),
     chosen_theme: url_property('theme', 'paper'),
     chosen_bare: url_property('bare', '0', true),
     chosen_advanced: url_property('advanced', '0'),

--- a/lib/chartist-plugin-legend.js
+++ b/lib/chartist-plugin-legend.js
@@ -24,7 +24,7 @@
         classNames: false,
         removeAll: false,
         legendNames: false,
-        legendState: false,
+        legendState: [],
         clickable: true,
         onClick: null,
         position: 'top',
@@ -200,7 +200,10 @@
                     applyLegendStateToChart(legends, seriesMetadata, useLabels);
 
                     if (options.onClick) {
-                        options.onClick(chart, e, _.clone(legends));
+                        // If they're all active, pass an empty state array
+                        var allActive = !legends.find(element => !element.active);
+                        options.onClick(chart, e,
+                            allActive ? [] : _.filter(legends, l => l.active).map(e => e.text));
                     }
                 });
             }
@@ -228,17 +231,10 @@
                     seriesMetadata[seriesIndex].legend = i;
                 });
     
+                // If we received some state, always use it to set active
                 var active = true;
-                if (options.legendState) {
-                    var found = options.legendState.find(element => element.text == legendText);
-                    if (found) {
-                        active = found.active;
-                    }
-                    else {
-                        // If that location is not in the saved state, only make it
-                        // selected if everything that was saved is selected
-                        active = !options.legendState.find(element => !element.active);
-                    }
+                if (options.legendState.length > 0) {
+                    active = options.legendState.indexOf(legendText) >= 0;
                 }
 
                 legends.push({


### PR DESCRIPTION
Note that this loses the ability to have selection preserve per domain, which would get too messy with URL preservation.

Also, small thing I can't figure out: once the selected state gets on the URL, I can't get rid of it, even if I have no state. i.e. the value is gone, but URL still has `select=`. Not a big deal, but makes the URL not as clean as it could be.