### PR TITLE
Remove URL params that have default values

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,8 +749,16 @@ function all_localities(csse) {
 function url_property(name, default_value, nav) {
   return {
     get() { return this.$route.query[name] || default_value },
-    set(value) { this.$router[nav ? 'push' : 'replace']({query: _.defaults(
-      { [name]: value }, this.$route.query) }).catch(err => {}); }
+    set(value) {
+      var o = _.defaults({ [name]: value }, this.$route.query);
+
+      // If it's the default value, get rid of it to clean up the URL
+      if (value == default_value) {
+        delete o[name];
+      }
+
+      this.$router[nav ? 'push' : 'replace']({query: o }).catch(err => {});
+    }
   };
 }
 function score_series(stat, s) {


### PR DESCRIPTION
Before this change, we accumulate query params even if they go back to their default value. e.g. switch to `deaths` and back to `confirmed`, and you have `series=confirmed` on the url.

With this change, the URL is kept clean of default values.