### PR TITLE
Use a sliding window for deltas

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,11 +541,14 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
   scale = scale || 'log10';
   if (chart) { chart.detach(); }
   if (stat == 'deltas') {
+    // How many days back do we go to calculate the delta
+    const deltaInterval = 4;
     extract.series = _.map(extract.series, p => [p[0], _.map(p[1], (d, i) => {
       if (i == 0) { return null; }
+      var prevIndex = Math.max(0, i - deltaInterval);
       var cur = (d ? d.value : 0),
-          prev = (p[1][i-1] ? p[1][i-1].value : 0);
-      return _.defaults({value: cur - prev}, d);
+          prev = (p[1][prevIndex] ? p[1][prevIndex].value : 0);
+      return _.defaults({value: (cur - prev) / (i - prevIndex)}, d);
     })]);
   }
   if (scale.startsWith('log')) {


### PR DESCRIPTION
This is not quite ready, but is for initial discussion about #40.

The reasoning I made is that too much choice is bad, and that maybe we should only offer sliding deltas since plain deltas are so noisy. We could rename it to sliding deltas.

I made the number of days we look back configurable (in code only), as `deltaInterval`. So please experiment by changing this hard coded value. Setting it to 1 is the old behavior. I set it to 4 for now, which significantly smoothens the delta graphs (while keeping their overall shape).

But I'd like to discuss a small problem: because I take the average delta between the first and last day (of the interval), it would be a more proper estimate for the **middle** day. But right now, I use it as the value for the last day. So if the deltas are increasing a lot, we end up with a number that's a little low for the date it's assigned to (and vice versa if going down). Potential solution is to make the sliding window be **centered** around the current date, and I could try that (not a hard change). That still leaves some pain point at the end of the graph, since there is no 'future' data. And obviously, this problem gets worse with larger sliding windows. There are probably some crazy extrapolation algorithms to deal with that if we care.