### PR TITLE
Hack to fix population for New York City

### DIFF
--- a/lib/population.js
+++ b/lib/population.js
@@ -4609,7 +4609,7 @@ var POPULATION = {
   "Douglas, NE": 566880,
   "Carna\u00edba, PE, BRA": 19491,
   "Storey, NV": 4029,
-  "New York, NY": 1628701,
+  "New York, NY": 8400000,
   "Paraibuna, SP, BRA": 18180,
   "Lizarda, TO, BRA": 3748,
   "Beltrami, MN": 46847,

--- a/lib/src/make_pop.py
+++ b/lib/src/make_pop.py
@@ -52,6 +52,9 @@ for k,v in data.items():
     k = k.replace(' Borough, ', ', ')
     if "population" in v.keys():
         pop[k] = v["population"]
+        # No idea why NYC populaton is wrong in the data.
+        if k == 'New York, NY':
+            pop[k] = 8400000
         present += 1
     else:
         print("no population for ", k)


### PR DESCRIPTION
Correct population number for New York City; old population was just 1.6M which appears to be Manhattan, correct population is approximately 8.4M.