### PR TITLE
Add support for growth mode, aka log-log plot of recent changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,7 +591,8 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
     // When using log scale, we need to make sure we don't end up with entries
     // that are missing their 'value' (or 'x/y') properties, as that breaks it
     extract.series = _.map(extract.series, p => [p[0], _.map(p[1], d => {
-      return d && (d.value || (d.x && d.y)) ? d : null;
+      return d && (d.value && d.value > 0 || d.x && d.x > 0 && d.y && d.y > 0)
+        ? d : null;
     })]);
   }
   chart = new Chartist.Line('#chart', {

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@ Customized charts are directly linkable by URL.  URL parameters can be edited di
 <table>
 <tr><td>Domain:</td><td><input v-model.lazy="chosen_domain"> (US/Intl)</td></tr>
 <tr><td>Series:</td><td><input v-model.lazy="chosen_series"> (confirmed/deaths)</td></tr>
-<tr><td>Stat:</td><td><input v-model.lazy="chosen_stat"> (totals/deltas)</td></tr>
+<tr><td>Stat:</td><td><input v-model.lazy="chosen_stat"> (totals/daily/7day/growth)</td></tr>
 <tr><td>Scale:</td><td><input v-model.lazy="chosen_scale"> (linear/log10)</td></tr>
 <tr><td>Norm:</td><td><input v-model.lazy="chosen_norm"> (none/first/pop)</td></tr>
 <tr><td>Start:</td><td><input v-model.lazy="chosen_start"> (>=num, or m/d/y)</td></tr>
@@ -559,6 +559,7 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
      select, updateSelect) {
   scale = scale || 'log10';
   if (chart) { chart.detach(); }
+  var isGrowthChart = (stat == 'growth');
   if (parse_delta(stat)) {
     // How many days back do we go to calculate the delta
     const deltaInterval = parse_delta(stat);
@@ -570,9 +571,23 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
       return _.defaults({value: (cur - prev) / deltaInterval}, d);
     })]);
   }
+  else if (isGrowthChart) {
+    // In this mode, We plot an x,y graph with x as the total count and 'y' as
+    // the weekly count (not the average for one day, unlike with 'deltas')
+    extract.series = _.map(extract.series, p => [p[0],_.map(p[1], (d, i) => {
+      var prevIndex = i - 7; // Use last week for 'x'
+      var cur = (d ? d.value : 0),
+          prev = (p[1][prevIndex] ? p[1][prevIndex].value : 0);
+      var point = _.defaults({ x: cur, y: (cur - prev) }, d);
+      delete point["value"]; // delete unwanted 'value' prop as we have x,y
+      return point;
+    })]);
+  }
   if (scale.startsWith('log')) {
+    // When using log scale, we need to make sure we don't end up with entries
+    // that are missing their 'value' (or 'x/y') properties, as that breaks it
     extract.series = _.map(extract.series, p => [p[0], _.map(p[1], d => {
-      return d && d.value && d.value > 0 ? d : null;
+      return d && (d.value || d.x) ? d : null;
     })]);
   }
   chart = new Chartist.Line('#chart', {
@@ -594,11 +609,15 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
         return index % 7  === (parse_date(extract.labels[0]) ?
             (extract.labels.length - 1) % 7 : 0) ? value : null;
       },
+      type: isGrowthChart ? Chartist.AutoScaleAxis : undefined,
+      scale: isGrowthChart ? scale : 'linear',
+      onlyInteger: true,
     },
     axisY: {
       showMinorGrid: true,
       type: Chartist.AutoScaleAxis,
       scale: scale,
+      onlyInteger: true,
     },
     chartPadding: {
       top: 50,
@@ -794,7 +813,7 @@ theapp = new Vue({
     data_feed_name: data_feed_name,
     siteurl: window.location.protocol + '//' + window.location.host + '/',
     series_choices: ['confirmed', 'deaths'], // 'recovered' seems incomplete.
-    stat_choices: ['totals', 'daily', '7day'],
+    stat_choices: ['totals', 'daily', '7day', 'growth'],
     scale_choices: ['linear', 'log10'],
     norm_choices: ['none', 'first', 'pop'],
     added_locality: null,

--- a/index.html
+++ b/index.html
@@ -609,8 +609,9 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
       gridMinor: 'ct-grid-minor'
     },
     axisX: {
-      labelInterpolationFnc: function skipLabels(value, index) {
-        return index % 7  === (parse_date(extract.labels[0]) ?
+      labelInterpolationFnc: (value, index) => {
+        return isGrowthChart && scale.startsWith('log') ? value :
+          index % 7  === (parse_date(extract.labels[0]) ?
             (extract.labels.length - 1) % 7 : 0) ? value : null;
       },
       type: isGrowthChart ? Chartist.AutoScaleAxis : undefined,

--- a/index.html
+++ b/index.html
@@ -528,6 +528,7 @@ function extract_data(csse, domain, field, stat, topcount, include) {
 function yaxis_title(field, stat, scale, norm) {
   var stat_desc =
       stat == 'totals' ? 'Total cumulative ' :
+      stat == 'growth' ? 'Weekly new ' :
       parse_delta(stat) == 1 ? 'Daily new ' :
       parse_delta(stat) + '-day average of daily ';
   var desc = stat_desc +
@@ -538,7 +539,10 @@ function yaxis_title(field, stat, scale, norm) {
              (scale && scale.startsWith('log') ? ' (log scale)' : '');
   return desc;
 }
-function xaxis_title(field, start, norm) {
+function xaxis_title(field, stat, scale, norm, start) {
+  if (stat == 'growth') {
+    return yaxis_title(field, 'totals', scale, norm);
+  }
   if (start.startsWith('>=')) {
     if (norm == 'pop') {
       return 'Days since ' + start.slice(2) + ' per million ' + field;
@@ -916,8 +920,8 @@ theapp = new Vue({
 
       var ytitle = yaxis_title(this.chosen_series, this.chosen_stat,
           this.chosen_scale, this.chosen_norm);
-      var xtitle = xaxis_title(this.chosen_series, this.chosen_start,
-          this.chosen_norm);
+      var xtitle = xaxis_title(this.chosen_series, this.chosen_stat,
+          this.chosen_scale, this.chosen_norm, this.chosen_start);
       plot_series(ordered,
           this.chosen_stat, this.chosen_scale, this.chosen_norm,
           xtitle, ytitle,

--- a/index.html
+++ b/index.html
@@ -591,7 +591,7 @@ function plot_series(extract, stat, scale, norm, xaxis, yaxis,
     // When using log scale, we need to make sure we don't end up with entries
     // that are missing their 'value' (or 'x/y') properties, as that breaks it
     extract.series = _.map(extract.series, p => [p[0], _.map(p[1], d => {
-      return d && (d.value || d.x) ? d : null;
+      return d && (d.value || (d.x && d.y)) ? d : null;
     })]);
   }
   chart = new Chartist.Line('#chart', {


### PR DESCRIPTION
This is the initial change for #12. It turned out to be relatively straightforward.

Note that I tried the match the behavior of https://aatishb.com/covidtrends/, which is what that youtube video is showing. The resulting graph closely matches that site, so there is some confidence that it's correct. e.g. try testing it with `?include=China%3BAustralia%3BJapan%3BS%20Korea&advanced=1&start=>%3D30&domain=Intl&stat=growth`.

![image](https://user-images.githubusercontent.com/556238/79049285-9ff46300-7bd7-11ea-9247-2430b593cb19.png)

Misc comments:
- I called it 'growth' for lack of a better short name
- The graph looks a bit rough with low numbers when using log scale (long straight initial line). It's best to start with >= 80
- It can be used in either log/log mode or linear/linear mode. Obviously, log is more interesting.
- The axis names are wrong, as I have not touch that logic and I need to customize it for this new mode. I'll look at that.
- In log mode, the x axis labels are missing. Not sure why, but I'll look into that.